### PR TITLE
PHI 전처리 완료

### DIFF
--- a/PHI_19_21_only.ipynb
+++ b/PHI_19_21_only.ipynb
@@ -1,0 +1,1838 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 160,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 161,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 데이터 불러오기\n",
+    "a_hh = pd.read_csv(\"C:/Users/user/Desktop/중간프로젝트/의료패널 데이터/csv파일/a_hh.csv\")\n",
+    "a_id = pd.read_csv(\"C:/Users/user/Desktop/중간프로젝트/의료패널 데이터/csv파일/a_id.csv\")\n",
+    "a_ind = pd.read_csv(\"C:/Users/user/Desktop/중간프로젝트/의료패널 데이터/csv파일/a_ind.csv\")\n",
+    "a_ms = pd.read_csv(\"C:/Users/user/Desktop/중간프로젝트/의료패널 데이터/csv파일/a_ms.csv\")\n",
+    "a_phi = pd.read_csv(\"C:/Users/user/Desktop/중간프로젝트/의료패널 데이터/csv파일/a_phi.csv\")\n",
+    "\n",
+    "b_hh = pd.read_csv(\"C:/Users/user/Desktop/중간프로젝트/의료패널 데이터/csv파일/b_hh.csv\")\n",
+    "b_id = pd.read_csv(\"C:/Users/user/Desktop/중간프로젝트/의료패널 데이터/csv파일/b_id.csv\")\n",
+    "b_ind = pd.read_csv(\"C:/Users/user/Desktop/중간프로젝트/의료패널 데이터/csv파일/b_ind.csv\")\n",
+    "b_ms = pd.read_csv(\"C:/Users/user/Desktop/중간프로젝트/의료패널 데이터/csv파일/b_ms.csv\")\n",
+    "b_phi = pd.read_csv(\"C:/Users/user/Desktop/중간프로젝트/의료패널 데이터/csv파일/b_phi.csv\")\n",
+    "\n",
+    "c_hh = pd.read_csv(\"C:/Users/user/Desktop/중간프로젝트/의료패널 데이터/csv파일/c_hh.csv\")\n",
+    "c_id = pd.read_csv(\"C:/Users/user/Desktop/중간프로젝트/의료패널 데이터/csv파일/c_id.csv\")\n",
+    "c_ind = pd.read_csv(\"C:/Users/user/Desktop/중간프로젝트/의료패널 데이터/csv파일/c_ind.csv\")\n",
+    "c_ms = pd.read_csv(\"C:/Users/user/Desktop/중간프로젝트/의료패널 데이터/csv파일/c_ms.csv\")\n",
+    "c_phi = pd.read_csv(\"C:/Users/user/Desktop/중간프로젝트/의료패널 데이터/csv파일/c_phi.csv\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# PHI 데이터 구조 확인"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 162,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# a -> 19, b -> 20, c->21 각 데이터에 연도 컬럼 추가하기\n",
+    "a_phi[\"year\"] = 2019\n",
+    "b_phi[\"year\"] = 2020\n",
+    "c_phi[\"year\"] = 2021"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 163,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(21538, 26)"
+      ]
+     },
+     "execution_count": 163,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "a_phi.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 164,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(21345, 26)"
+      ]
+     },
+     "execution_count": 164,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "b_phi.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 165,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(21392, 26)"
+      ]
+     },
+     "execution_count": 165,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "c_phi.shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## b_phi[PHI_PID]\n",
+    "- a, c는 PHI_PID에 문제 없는데 b는 ...으로 표시된 행이 너무 많아!\n",
+    "- 나중에 PHI_PID가 9글자 이상인 걸 중복가입으로 생각하고 제거해줄 건데 데이터가 이꼴이면 문제가 있다! 전처리 해줘야 한당"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 166,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>HHID</th>\n",
+       "      <th>PHI_N</th>\n",
+       "      <th>PHI_PID</th>\n",
+       "      <th>PHI_PID1</th>\n",
+       "      <th>PHI_PID2</th>\n",
+       "      <th>PHI_PID3</th>\n",
+       "      <th>PHI_PID4</th>\n",
+       "      <th>PHI_PID5</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>144191011.0</td>\n",
+       "      <td>301.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>14419101.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>244007011.0</td>\n",
+       "      <td>201.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>24400702.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>112185011.0</td>\n",
+       "      <td>102.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>11218502.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>125103011.0</td>\n",
+       "      <td>109.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>12510302.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>232548011.0</td>\n",
+       "      <td>201.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>23254802.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>21340</th>\n",
+       "      <td>155292011.0</td>\n",
+       "      <td>207.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>15529202.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>21341</th>\n",
+       "      <td>214255011.0</td>\n",
+       "      <td>203.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>21425502.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>21342</th>\n",
+       "      <td>214202011.0</td>\n",
+       "      <td>106.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>21420202.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>21343</th>\n",
+       "      <td>122154011.0</td>\n",
+       "      <td>102.0</td>\n",
+       "      <td>12215401/12215402/12215404/12215405</td>\n",
+       "      <td>12215401.0</td>\n",
+       "      <td>12215402.0</td>\n",
+       "      <td>12215404.0</td>\n",
+       "      <td>12215405.0</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>21344</th>\n",
+       "      <td>202253011.0</td>\n",
+       "      <td>101.0</td>\n",
+       "      <td>20225301/20225302/20225303/20225304</td>\n",
+       "      <td>20225301.0</td>\n",
+       "      <td>20225302.0</td>\n",
+       "      <td>20225303.0</td>\n",
+       "      <td>20225304.0</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>21345 rows × 8 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "              HHID  PHI_N                                            PHI_PID  \\\n",
+       "0      144191011.0  301.0                                                ...   \n",
+       "1      244007011.0  201.0                                                ...   \n",
+       "2      112185011.0  102.0                                                ...   \n",
+       "3      125103011.0  109.0                                                ...   \n",
+       "4      232548011.0  201.0                                                ...   \n",
+       "...            ...    ...                                                ...   \n",
+       "21340  155292011.0  207.0                                                ...   \n",
+       "21341  214255011.0  203.0                                                ...   \n",
+       "21342  214202011.0  106.0                                                ...   \n",
+       "21343  122154011.0  102.0                12215401/12215402/12215404/12215405   \n",
+       "21344  202253011.0  101.0                20225301/20225302/20225303/20225304   \n",
+       "\n",
+       "         PHI_PID1    PHI_PID2    PHI_PID3    PHI_PID4  PHI_PID5  \n",
+       "0      14419101.0         NaN         NaN         NaN       NaN  \n",
+       "1      24400702.0         NaN         NaN         NaN       NaN  \n",
+       "2      11218502.0         NaN         NaN         NaN       NaN  \n",
+       "3      12510302.0         NaN         NaN         NaN       NaN  \n",
+       "4      23254802.0         NaN         NaN         NaN       NaN  \n",
+       "...           ...         ...         ...         ...       ...  \n",
+       "21340  15529202.0         NaN         NaN         NaN       NaN  \n",
+       "21341  21425502.0         NaN         NaN         NaN       NaN  \n",
+       "21342  21420202.0         NaN         NaN         NaN       NaN  \n",
+       "21343  12215401.0  12215402.0  12215404.0  12215405.0       NaN  \n",
+       "21344  20225301.0  20225302.0  20225303.0  20225304.0       NaN  \n",
+       "\n",
+       "[21345 rows x 8 columns]"
+      ]
+     },
+     "execution_count": 166,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "b_phi.iloc[:,:8]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 167,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0                                                      ...\n",
+       "1                                                      ...\n",
+       "2                                                      ...\n",
+       "3                                                      ...\n",
+       "4                                                      ...\n",
+       "                               ...                        \n",
+       "21340                                                  ...\n",
+       "21341                                                  ...\n",
+       "21342                                                  ...\n",
+       "21343                  12215401/12215402/12215404/12215405\n",
+       "21344                  20225301/20225302/20225303/20225304\n",
+       "Name: PHI_PID, Length: 21345, dtype: object"
+      ]
+     },
+     "execution_count": 167,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "b_phi[\"PHI_PID\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 168,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0"
+      ]
+     },
+     "execution_count": 168,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# 결측값으로 표시된게 없어! ...으로 기입된건가?\n",
+    "b_phi[\"PHI_PID\"].isna().sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 169,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "PHI_PID\n",
+       "                                                                                                                                                                                                17525301    30\n",
+       "                                                                                                                                                                                                12324702    22\n",
+       "                                                                                                                                                                                                23504401    21\n",
+       "                                                                                                                                                                                                15424701    21\n",
+       "                                                                                                                                                                                                15527901    20\n",
+       "                                                                                                                                                                                                            ..\n",
+       "                                                                                                                                                                                                16251502     1\n",
+       "                                                                                                                                                                                                13319102     1\n",
+       "                                                                                                                                                                                                22352904     1\n",
+       "                                                                                                                                                                                                22402401     1\n",
+       "20225301/20225302/20225303/20225304                                                                                                                                                                          1\n",
+       "Name: count, Length: 10045, dtype: int64"
+      ]
+     },
+     "execution_count": 169,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# 공백인건가..?\n",
+    "b_phi[\"PHI_PID\"].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 170,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Series([], Name: PHI_PID, dtype: object)"
+      ]
+     },
+     "execution_count": 170,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "b_phi.loc[b_phi[\"PHI_PID\"]==\"...\", \"PHI_PID\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 171,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Series([], Name: PHI_PID, dtype: object)"
+      ]
+     },
+     "execution_count": 171,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "b_phi.loc[b_phi[\"PHI_PID\"]==\" \", \"PHI_PID\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 172,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "PHI_PID\n",
+       "17525301                               30\n",
+       "12324702                               22\n",
+       "23504401                               21\n",
+       "15424701                               21\n",
+       "15527901                               20\n",
+       "                                       ..\n",
+       "16251502                                1\n",
+       "13319102                                1\n",
+       "22352904                                1\n",
+       "22402401                                1\n",
+       "20225301/20225302/20225303/20225304     1\n",
+       "Name: count, Length: 10045, dtype: int64"
+      ]
+     },
+     "execution_count": 172,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# 일단 공백제거,..!\n",
+    "b_phi[\"PHI_PID\"] = b_phi[\"PHI_PID\"].str.strip()\n",
+    "b_phi[\"PHI_PID\"].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 173,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>HHID</th>\n",
+       "      <th>PHI_N</th>\n",
+       "      <th>PHI_PID</th>\n",
+       "      <th>PHI_PID1</th>\n",
+       "      <th>PHI_PID2</th>\n",
+       "      <th>PHI_PID3</th>\n",
+       "      <th>PHI_PID4</th>\n",
+       "      <th>PHI_PID5</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>144191011.0</td>\n",
+       "      <td>301.0</td>\n",
+       "      <td>14419101</td>\n",
+       "      <td>14419101.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>244007011.0</td>\n",
+       "      <td>201.0</td>\n",
+       "      <td>24400702</td>\n",
+       "      <td>24400702.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>112185011.0</td>\n",
+       "      <td>102.0</td>\n",
+       "      <td>11218502</td>\n",
+       "      <td>11218502.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>125103011.0</td>\n",
+       "      <td>109.0</td>\n",
+       "      <td>12510302</td>\n",
+       "      <td>12510302.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>232548011.0</td>\n",
+       "      <td>201.0</td>\n",
+       "      <td>23254802</td>\n",
+       "      <td>23254802.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>21340</th>\n",
+       "      <td>155292011.0</td>\n",
+       "      <td>207.0</td>\n",
+       "      <td>15529202</td>\n",
+       "      <td>15529202.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>21341</th>\n",
+       "      <td>214255011.0</td>\n",
+       "      <td>203.0</td>\n",
+       "      <td>21425502</td>\n",
+       "      <td>21425502.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>21342</th>\n",
+       "      <td>214202011.0</td>\n",
+       "      <td>106.0</td>\n",
+       "      <td>21420202</td>\n",
+       "      <td>21420202.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>21343</th>\n",
+       "      <td>122154011.0</td>\n",
+       "      <td>102.0</td>\n",
+       "      <td>12215401/12215402/12215404/12215405</td>\n",
+       "      <td>12215401.0</td>\n",
+       "      <td>12215402.0</td>\n",
+       "      <td>12215404.0</td>\n",
+       "      <td>12215405.0</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>21344</th>\n",
+       "      <td>202253011.0</td>\n",
+       "      <td>101.0</td>\n",
+       "      <td>20225301/20225302/20225303/20225304</td>\n",
+       "      <td>20225301.0</td>\n",
+       "      <td>20225302.0</td>\n",
+       "      <td>20225303.0</td>\n",
+       "      <td>20225304.0</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>21345 rows × 8 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "              HHID  PHI_N                              PHI_PID    PHI_PID1  \\\n",
+       "0      144191011.0  301.0                             14419101  14419101.0   \n",
+       "1      244007011.0  201.0                             24400702  24400702.0   \n",
+       "2      112185011.0  102.0                             11218502  11218502.0   \n",
+       "3      125103011.0  109.0                             12510302  12510302.0   \n",
+       "4      232548011.0  201.0                             23254802  23254802.0   \n",
+       "...            ...    ...                                  ...         ...   \n",
+       "21340  155292011.0  207.0                             15529202  15529202.0   \n",
+       "21341  214255011.0  203.0                             21425502  21425502.0   \n",
+       "21342  214202011.0  106.0                             21420202  21420202.0   \n",
+       "21343  122154011.0  102.0  12215401/12215402/12215404/12215405  12215401.0   \n",
+       "21344  202253011.0  101.0  20225301/20225302/20225303/20225304  20225301.0   \n",
+       "\n",
+       "         PHI_PID2    PHI_PID3    PHI_PID4  PHI_PID5  \n",
+       "0             NaN         NaN         NaN       NaN  \n",
+       "1             NaN         NaN         NaN       NaN  \n",
+       "2             NaN         NaN         NaN       NaN  \n",
+       "3             NaN         NaN         NaN       NaN  \n",
+       "4             NaN         NaN         NaN       NaN  \n",
+       "...           ...         ...         ...       ...  \n",
+       "21340         NaN         NaN         NaN       NaN  \n",
+       "21341         NaN         NaN         NaN       NaN  \n",
+       "21342         NaN         NaN         NaN       NaN  \n",
+       "21343  12215402.0  12215404.0  12215405.0       NaN  \n",
+       "21344  20225302.0  20225303.0  20225304.0       NaN  \n",
+       "\n",
+       "[21345 rows x 8 columns]"
+      ]
+     },
+     "execution_count": 173,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "b_phi.iloc[:,:8] # 해결!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 전처리"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 데이터 병합"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 174,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a = a_phi.columns\n",
+    "b = b_phi.columns\n",
+    "c = c_phi.columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 175,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Index(['HHID', 'PHI_N', 'PHI_PID', 'PHI_PID1', 'PHI_PID2', 'PHI_PID3',\n",
+       "       'PHI_PID4', 'PHI_PID5', 'PHI1', 'PHI2', 'PHI3', 'PHI4', 'PHI4_1_D',\n",
+       "       'PHI4_2_D', 'PHI4_3_D', 'PHI4_4_D', 'PHI4_5_D', 'PHI4_6_D', 'PHI4_7_D',\n",
+       "       'PHI4_8_D', 'PHI5', 'PHI6', 'PHR1', 'PHR2', 'PHR3', 'year'],\n",
+       "      dtype='object')"
+      ]
+     },
+     "execution_count": 175,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "a"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 176,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([ True,  True,  True,  True,  True,  True,  True,  True,  True,\n",
+       "        True,  True,  True,  True,  True,  True,  True,  True,  True,\n",
+       "        True,  True,  True,  True,  True,  True,  True,  True])"
+      ]
+     },
+     "execution_count": 176,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "a == b"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 177,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([ True,  True,  True,  True,  True,  True,  True,  True,  True,\n",
+       "        True,  True,  True,  True,  True,  True,  True,  True,  True,\n",
+       "        True,  True,  True,  True,  True,  True,  True,  True])"
+      ]
+     },
+     "execution_count": 177,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "a == c"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 178,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([ True,  True,  True,  True,  True,  True,  True,  True,  True,\n",
+       "        True,  True,  True,  True,  True,  True,  True,  True,  True,\n",
+       "        True,  True,  True,  True,  True,  True,  True,  True])"
+      ]
+     },
+     "execution_count": 178,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "b == c"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "- a, b, c는 모두 같은 컬럼을 갖는다."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 179,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(64275, 26)"
+      ]
+     },
+     "execution_count": 179,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# 병합\n",
+    "phi = pd.concat([a_phi, b_phi, c_phi])\n",
+    "phi.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 180,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "year\n",
+       "2019    21538\n",
+       "2021    21392\n",
+       "2020    21345\n",
+       "Name: count, dtype: int64"
+      ]
+     },
+     "execution_count": 180,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "phi[\"year\"].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 변수명 변경"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 181,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Index(['HHID', 'PHI_N', 'PHI_PID', 'PHI_PID1', 'PHI_PID2', 'PHI_PID3',\n",
+       "       'PHI_PID4', 'PHI_PID5', 'PHI1', 'PHI2', 'PHI3', 'PHI4', 'PHI4_1_D',\n",
+       "       'PHI4_2_D', 'PHI4_3_D', 'PHI4_4_D', 'PHI4_5_D', 'PHI4_6_D', 'PHI4_7_D',\n",
+       "       'PHI4_8_D', 'PHI5', 'PHI6', 'PHR1', 'PHR2', 'PHR3', 'year'],\n",
+       "      dtype='object')"
+      ]
+     },
+     "execution_count": 181,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "phi.columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 182,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "phi.columns = [\"HHID\", \"PHI_N\",\"PHI_PID\",\"PIDWON1\",\"PIDWON2\",\"PIDWON3\",\"PIDWON4\",\"PIDWON5\", \"PHI_Y\",\"PHI_M\",\"PHI_FORM\",\"PHI_TYPE\",\"PHI_TYPE_D\",\"PHI_TYPE_C\",\"PHI_TYPE_A\",\"PHI_TYPE_N\",\"PHI_TYPE_T\",\"PHI_TYPE_AL\",\"PHI_TYPE_M\",\"PHI_TYPE_O\",\"PHI_premium_yn\",\"PHI_premium\",\"PHI_claim_yn\",\"PHI_benefit_yn\",\"PHI_benefit\", \"year\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 183,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Index(['HHID', 'PHI_N', 'PHI_PID', 'PIDWON1', 'PIDWON2', 'PIDWON3', 'PIDWON4',\n",
+       "       'PIDWON5', 'PHI_Y', 'PHI_M', 'PHI_FORM', 'PHI_TYPE', 'PHI_TYPE_D',\n",
+       "       'PHI_TYPE_C', 'PHI_TYPE_A', 'PHI_TYPE_N', 'PHI_TYPE_T', 'PHI_TYPE_AL',\n",
+       "       'PHI_TYPE_M', 'PHI_TYPE_O', 'PHI_premium_yn', 'PHI_premium',\n",
+       "       'PHI_claim_yn', 'PHI_benefit_yn', 'PHI_benefit', 'year'],\n",
+       "      dtype='object')"
+      ]
+     },
+     "execution_count": 183,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "phi.columns"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 결측값 변경"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 184,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'pandas.core.frame.DataFrame'>\n",
+      "Index: 64275 entries, 0 to 21391\n",
+      "Data columns (total 26 columns):\n",
+      " #   Column          Non-Null Count  Dtype  \n",
+      "---  ------          --------------  -----  \n",
+      " 0   HHID            64275 non-null  float64\n",
+      " 1   PHI_N           64275 non-null  float64\n",
+      " 2   PHI_PID         64275 non-null  object \n",
+      " 3   PIDWON1         64275 non-null  float64\n",
+      " 4   PIDWON2         584 non-null    float64\n",
+      " 5   PIDWON3         117 non-null    float64\n",
+      " 6   PIDWON4         47 non-null     float64\n",
+      " 7   PIDWON5         2 non-null      float64\n",
+      " 8   PHI_Y           64275 non-null  float64\n",
+      " 9   PHI_M           64275 non-null  float64\n",
+      " 10  PHI_FORM        64275 non-null  float64\n",
+      " 11  PHI_TYPE        54883 non-null  object \n",
+      " 12  PHI_TYPE_D      54883 non-null  float64\n",
+      " 13  PHI_TYPE_C      54883 non-null  float64\n",
+      " 14  PHI_TYPE_A      54883 non-null  float64\n",
+      " 15  PHI_TYPE_N      54883 non-null  float64\n",
+      " 16  PHI_TYPE_T      54883 non-null  float64\n",
+      " 17  PHI_TYPE_AL     54883 non-null  float64\n",
+      " 18  PHI_TYPE_M      54883 non-null  float64\n",
+      " 19  PHI_TYPE_O      54883 non-null  float64\n",
+      " 20  PHI_premium_yn  64275 non-null  float64\n",
+      " 21  PHI_premium     64275 non-null  float64\n",
+      " 22  PHI_claim_yn    64275 non-null  float64\n",
+      " 23  PHI_benefit_yn  5133 non-null   float64\n",
+      " 24  PHI_benefit     5005 non-null   float64\n",
+      " 25  year            64275 non-null  int64  \n",
+      "dtypes: float64(23), int64(1), object(2)\n",
+      "memory usage: 13.2+ MB\n"
+     ]
+    }
+   ],
+   "source": [
+    "phi.info()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 185,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "HHID                  0\n",
+       "PHI_N                 0\n",
+       "PHI_PID               0\n",
+       "PIDWON1               0\n",
+       "PIDWON2           63691\n",
+       "PIDWON3           64158\n",
+       "PIDWON4           64228\n",
+       "PIDWON5           64273\n",
+       "PHI_Y                 0\n",
+       "PHI_M                 0\n",
+       "PHI_FORM              0\n",
+       "PHI_TYPE           9392\n",
+       "PHI_TYPE_D         9392\n",
+       "PHI_TYPE_C         9392\n",
+       "PHI_TYPE_A         9392\n",
+       "PHI_TYPE_N         9392\n",
+       "PHI_TYPE_T         9392\n",
+       "PHI_TYPE_AL        9392\n",
+       "PHI_TYPE_M         9392\n",
+       "PHI_TYPE_O         9392\n",
+       "PHI_premium_yn        0\n",
+       "PHI_premium           0\n",
+       "PHI_claim_yn          0\n",
+       "PHI_benefit_yn    59142\n",
+       "PHI_benefit       59270\n",
+       "year                  0\n",
+       "dtype: int64"
+      ]
+     },
+     "execution_count": 185,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "phi.isna().sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 186,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# -9 결측값으로 변경\n",
+    "import numpy as np\n",
+    "\n",
+    "phi[phi==-9] = np.nan\n",
+    "phi[phi=='-9'] = np.nan"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 187,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "HHID                  0\n",
+       "PHI_N                 0\n",
+       "PHI_PID               0\n",
+       "PIDWON1               0\n",
+       "PIDWON2           63691\n",
+       "PIDWON3           64158\n",
+       "PIDWON4           64228\n",
+       "PIDWON5           64273\n",
+       "PHI_Y              3895\n",
+       "PHI_M             19577\n",
+       "PHI_FORM            905\n",
+       "PHI_TYPE          10801\n",
+       "PHI_TYPE_D        10801\n",
+       "PHI_TYPE_C        10801\n",
+       "PHI_TYPE_A        10801\n",
+       "PHI_TYPE_N        10801\n",
+       "PHI_TYPE_T        10801\n",
+       "PHI_TYPE_AL       10801\n",
+       "PHI_TYPE_M        10801\n",
+       "PHI_TYPE_O        10801\n",
+       "PHI_premium_yn      803\n",
+       "PHI_premium        3187\n",
+       "PHI_claim_yn        462\n",
+       "PHI_benefit_yn    59142\n",
+       "PHI_benefit       59283\n",
+       "year                  0\n",
+       "dtype: int64"
+      ]
+     },
+     "execution_count": 187,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "phi.isna().sum()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 가구 별 단독 가입만 추출"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 188,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>HHID</th>\n",
+       "      <th>PHI_N</th>\n",
+       "      <th>PHI_PID</th>\n",
+       "      <th>PIDWON1</th>\n",
+       "      <th>PIDWON2</th>\n",
+       "      <th>PIDWON3</th>\n",
+       "      <th>PIDWON4</th>\n",
+       "      <th>PIDWON5</th>\n",
+       "      <th>PHI_Y</th>\n",
+       "      <th>PHI_M</th>\n",
+       "      <th>...</th>\n",
+       "      <th>PHI_TYPE_T</th>\n",
+       "      <th>PHI_TYPE_AL</th>\n",
+       "      <th>PHI_TYPE_M</th>\n",
+       "      <th>PHI_TYPE_O</th>\n",
+       "      <th>PHI_premium_yn</th>\n",
+       "      <th>PHI_premium</th>\n",
+       "      <th>PHI_claim_yn</th>\n",
+       "      <th>PHI_benefit_yn</th>\n",
+       "      <th>PHI_benefit</th>\n",
+       "      <th>year</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>86</th>\n",
+       "      <td>112075011.0</td>\n",
+       "      <td>105.0</td>\n",
+       "      <td>11207501,11207502</td>\n",
+       "      <td>11207501.0</td>\n",
+       "      <td>11207502.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>2003.0</td>\n",
+       "      <td>8.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>34980.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>2019</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>368</th>\n",
+       "      <td>112202011.0</td>\n",
+       "      <td>102.0</td>\n",
+       "      <td>11220201,11220202</td>\n",
+       "      <td>11220201.0</td>\n",
+       "      <td>11220202.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>2003.0</td>\n",
+       "      <td>6.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>14790.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>365256.0</td>\n",
+       "      <td>2019</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>879</th>\n",
+       "      <td>114008011.0</td>\n",
+       "      <td>103.0</td>\n",
+       "      <td>11400801,11400802</td>\n",
+       "      <td>11400801.0</td>\n",
+       "      <td>11400802.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>1996.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>...</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>40000.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>2019</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>968</th>\n",
+       "      <td>114068011.0</td>\n",
+       "      <td>102.0</td>\n",
+       "      <td>11406801,11406802</td>\n",
+       "      <td>11406801.0</td>\n",
+       "      <td>11406802.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>2015.0</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>38900.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>2019</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1322</th>\n",
+       "      <td>115106011.0</td>\n",
+       "      <td>105.0</td>\n",
+       "      <td>11510602,11510603</td>\n",
+       "      <td>11510602.0</td>\n",
+       "      <td>11510603.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>2014.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>100000.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>2019</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>20736</th>\n",
+       "      <td>254486011.0</td>\n",
+       "      <td>105.0</td>\n",
+       "      <td>25448601,25448602</td>\n",
+       "      <td>25448601.0</td>\n",
+       "      <td>25448602.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>1993.0</td>\n",
+       "      <td>6.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>29200.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>2021</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>20882</th>\n",
+       "      <td>255068011.0</td>\n",
+       "      <td>301.0</td>\n",
+       "      <td>25506801,25506802</td>\n",
+       "      <td>25506801.0</td>\n",
+       "      <td>25506802.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>2008.0</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>105300.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>2021</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>21126</th>\n",
+       "      <td>255465011.0</td>\n",
+       "      <td>102.0</td>\n",
+       "      <td>25546501,25546502</td>\n",
+       "      <td>25546501.0</td>\n",
+       "      <td>25546502.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>2006.0</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>216570.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>270000.0</td>\n",
+       "      <td>2021</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>21140</th>\n",
+       "      <td>255468011.0</td>\n",
+       "      <td>108.0</td>\n",
+       "      <td>25546801,25546802,25546803,25546804</td>\n",
+       "      <td>25546801.0</td>\n",
+       "      <td>25546802.0</td>\n",
+       "      <td>25546803.0</td>\n",
+       "      <td>25546804.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>2010.0</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>36410.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>120000.0</td>\n",
+       "      <td>2021</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>21268</th>\n",
+       "      <td>300046011.0</td>\n",
+       "      <td>103.0</td>\n",
+       "      <td>30004604,30004605,30004606</td>\n",
+       "      <td>30004604.0</td>\n",
+       "      <td>30004605.0</td>\n",
+       "      <td>30004606.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>1995.0</td>\n",
+       "      <td>7.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>42520.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>2021</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>584 rows × 26 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "              HHID  PHI_N                              PHI_PID     PIDWON1  \\\n",
+       "86     112075011.0  105.0                    11207501,11207502  11207501.0   \n",
+       "368    112202011.0  102.0                    11220201,11220202  11220201.0   \n",
+       "879    114008011.0  103.0                    11400801,11400802  11400801.0   \n",
+       "968    114068011.0  102.0                    11406801,11406802  11406801.0   \n",
+       "1322   115106011.0  105.0                    11510602,11510603  11510602.0   \n",
+       "...            ...    ...                                  ...         ...   \n",
+       "20736  254486011.0  105.0                    25448601,25448602  25448601.0   \n",
+       "20882  255068011.0  301.0                    25506801,25506802  25506801.0   \n",
+       "21126  255465011.0  102.0                    25546501,25546502  25546501.0   \n",
+       "21140  255468011.0  108.0  25546801,25546802,25546803,25546804  25546801.0   \n",
+       "21268  300046011.0  103.0           30004604,30004605,30004606  30004604.0   \n",
+       "\n",
+       "          PIDWON2     PIDWON3     PIDWON4  PIDWON5   PHI_Y  PHI_M  ...  \\\n",
+       "86     11207502.0         NaN         NaN      NaN  2003.0    8.0  ...   \n",
+       "368    11220202.0         NaN         NaN      NaN  2003.0    6.0  ...   \n",
+       "879    11400802.0         NaN         NaN      NaN  1996.0    NaN  ...   \n",
+       "968    11406802.0         NaN         NaN      NaN  2015.0    4.0  ...   \n",
+       "1322   11510603.0         NaN         NaN      NaN  2014.0    1.0  ...   \n",
+       "...           ...         ...         ...      ...     ...    ...  ...   \n",
+       "20736  25448602.0         NaN         NaN      NaN  1993.0    6.0  ...   \n",
+       "20882  25506802.0         NaN         NaN      NaN  2008.0    3.0  ...   \n",
+       "21126  25546502.0         NaN         NaN      NaN  2006.0    3.0  ...   \n",
+       "21140  25546802.0  25546803.0  25546804.0      NaN  2010.0   10.0  ...   \n",
+       "21268  30004605.0  30004606.0         NaN      NaN  1995.0    7.0  ...   \n",
+       "\n",
+       "       PHI_TYPE_T PHI_TYPE_AL  PHI_TYPE_M  PHI_TYPE_O  PHI_premium_yn  \\\n",
+       "86            2.0         2.0         2.0         2.0             1.0   \n",
+       "368           NaN         NaN         NaN         NaN             1.0   \n",
+       "879           2.0         2.0         2.0         2.0             3.0   \n",
+       "968           2.0         2.0         2.0         2.0             1.0   \n",
+       "1322          2.0         2.0         1.0         2.0             1.0   \n",
+       "...           ...         ...         ...         ...             ...   \n",
+       "20736         2.0         2.0         2.0         2.0             3.0   \n",
+       "20882         2.0         2.0         2.0         2.0             1.0   \n",
+       "21126         2.0         2.0         2.0         2.0             1.0   \n",
+       "21140         2.0         2.0         2.0         1.0             1.0   \n",
+       "21268         2.0         2.0         2.0         2.0             3.0   \n",
+       "\n",
+       "       PHI_premium  PHI_claim_yn  PHI_benefit_yn  PHI_benefit  year  \n",
+       "86         34980.0           2.0             NaN          NaN  2019  \n",
+       "368        14790.0           1.0             1.0     365256.0  2019  \n",
+       "879        40000.0           2.0             NaN          NaN  2019  \n",
+       "968        38900.0           2.0             NaN          NaN  2019  \n",
+       "1322      100000.0           2.0             NaN          NaN  2019  \n",
+       "...            ...           ...             ...          ...   ...  \n",
+       "20736      29200.0           2.0             NaN          NaN  2021  \n",
+       "20882     105300.0           2.0             NaN          NaN  2021  \n",
+       "21126     216570.0           1.0             1.0     270000.0  2021  \n",
+       "21140      36410.0           1.0             1.0     120000.0  2021  \n",
+       "21268      42520.0           2.0             NaN          NaN  2021  \n",
+       "\n",
+       "[584 rows x 26 columns]"
+      ]
+     },
+     "execution_count": 188,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# 동시가입 건수 : 21729 건\n",
+    "phi.loc[phi[\"PHI_PID\"].str.len() >= 9, :]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 189,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 독립가입 건 : 총 42546 행\n",
+    "phi_only = phi.loc[phi[\"PHI_PID\"].str.len() < 9, :]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 190,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "year\n",
+       "2019    21339\n",
+       "2021    21207\n",
+       "2020    21145\n",
+       "Name: count, dtype: int64"
+      ]
+     },
+     "execution_count": 190,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "phi_only['year'].value_counts() # 19-21 데이터 모두 포함 잘 되었다!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 191,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'pandas.core.frame.DataFrame'>\n",
+      "Index: 63691 entries, 0 to 21391\n",
+      "Data columns (total 26 columns):\n",
+      " #   Column          Non-Null Count  Dtype  \n",
+      "---  ------          --------------  -----  \n",
+      " 0   HHID            63691 non-null  float64\n",
+      " 1   PHI_N           63691 non-null  float64\n",
+      " 2   PHI_PID         63691 non-null  object \n",
+      " 3   PIDWON1         63691 non-null  float64\n",
+      " 4   PIDWON2         0 non-null      float64\n",
+      " 5   PIDWON3         0 non-null      float64\n",
+      " 6   PIDWON4         0 non-null      float64\n",
+      " 7   PIDWON5         0 non-null      float64\n",
+      " 8   PHI_Y           59828 non-null  float64\n",
+      " 9   PHI_M           44278 non-null  float64\n",
+      " 10  PHI_FORM        62788 non-null  float64\n",
+      " 11  PHI_TYPE        52971 non-null  object \n",
+      " 12  PHI_TYPE_D      52971 non-null  float64\n",
+      " 13  PHI_TYPE_C      52971 non-null  float64\n",
+      " 14  PHI_TYPE_A      52971 non-null  float64\n",
+      " 15  PHI_TYPE_N      52971 non-null  float64\n",
+      " 16  PHI_TYPE_T      52971 non-null  float64\n",
+      " 17  PHI_TYPE_AL     52971 non-null  float64\n",
+      " 18  PHI_TYPE_M      52971 non-null  float64\n",
+      " 19  PHI_TYPE_O      52971 non-null  float64\n",
+      " 20  PHI_premium_yn  62890 non-null  float64\n",
+      " 21  PHI_premium     60510 non-null  float64\n",
+      " 22  PHI_claim_yn    63229 non-null  float64\n",
+      " 23  PHI_benefit_yn  5060 non-null   float64\n",
+      " 24  PHI_benefit     4921 non-null   float64\n",
+      " 25  year            63691 non-null  int64  \n",
+      "dtypes: float64(23), int64(1), object(2)\n",
+      "memory usage: 13.1+ MB\n"
+     ]
+    }
+   ],
+   "source": [
+    "phi_only.info()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 192,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "C:\\Users\\user\\AppData\\Local\\Temp\\ipykernel_12876\\1473125934.py:2: SettingWithCopyWarning: \n",
+      "A value is trying to be set on a copy of a slice from a DataFrame\n",
+      "\n",
+      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
+      "  phi_only.drop([\"PHI_PID\",\"PIDWON2\",\"PIDWON3\",\"PIDWON4\",\"PIDWON5\"], axis=1, inplace=True)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# PHI_PID, PIDWON2~5 삭제\n",
+    "phi_only.drop([\"PHI_PID\",\"PIDWON2\",\"PIDWON3\",\"PIDWON4\",\"PIDWON5\"], axis=1, inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 193,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# PIDWON 변수명 변경\n",
+    "phi_only = phi_only.rename(columns={\"PIDWON1\":\"PIDWON\"})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 194,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>HHID</th>\n",
+       "      <th>PHI_N</th>\n",
+       "      <th>PIDWON</th>\n",
+       "      <th>PHI_Y</th>\n",
+       "      <th>PHI_M</th>\n",
+       "      <th>PHI_FORM</th>\n",
+       "      <th>PHI_TYPE</th>\n",
+       "      <th>PHI_TYPE_D</th>\n",
+       "      <th>PHI_TYPE_C</th>\n",
+       "      <th>PHI_TYPE_A</th>\n",
+       "      <th>...</th>\n",
+       "      <th>PHI_TYPE_T</th>\n",
+       "      <th>PHI_TYPE_AL</th>\n",
+       "      <th>PHI_TYPE_M</th>\n",
+       "      <th>PHI_TYPE_O</th>\n",
+       "      <th>PHI_premium_yn</th>\n",
+       "      <th>PHI_premium</th>\n",
+       "      <th>PHI_claim_yn</th>\n",
+       "      <th>PHI_benefit_yn</th>\n",
+       "      <th>PHI_benefit</th>\n",
+       "      <th>year</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>112003011.0</td>\n",
+       "      <td>101.0</td>\n",
+       "      <td>11200301.0</td>\n",
+       "      <td>2004.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>1,2,3,8</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>120000.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>60000.0</td>\n",
+       "      <td>2019</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>112003011.0</td>\n",
+       "      <td>102.0</td>\n",
+       "      <td>11200302.0</td>\n",
+       "      <td>2004.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>1,2,3,8</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>118000.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>2019</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>112010011.0</td>\n",
+       "      <td>101.0</td>\n",
+       "      <td>11201001.0</td>\n",
+       "      <td>2015.0</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>...</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>48710.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>2019</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>112010011.0</td>\n",
+       "      <td>102.0</td>\n",
+       "      <td>11201001.0</td>\n",
+       "      <td>2000.0</td>\n",
+       "      <td>7.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>1,2</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>62800.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>2019</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>112010011.0</td>\n",
+       "      <td>103.0</td>\n",
+       "      <td>11201002.0</td>\n",
+       "      <td>2012.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>1,2,3,8</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>201717.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>2019</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>5 rows × 21 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "          HHID  PHI_N      PIDWON   PHI_Y  PHI_M  PHI_FORM PHI_TYPE  \\\n",
+       "0  112003011.0  101.0  11200301.0  2004.0    NaN       3.0  1,2,3,8   \n",
+       "1  112003011.0  102.0  11200302.0  2004.0    NaN       3.0  1,2,3,8   \n",
+       "2  112010011.0  101.0  11201001.0  2015.0    3.0       2.0      NaN   \n",
+       "3  112010011.0  102.0  11201001.0  2000.0    7.0       1.0      1,2   \n",
+       "4  112010011.0  103.0  11201002.0  2012.0    2.0       3.0  1,2,3,8   \n",
+       "\n",
+       "   PHI_TYPE_D  PHI_TYPE_C  PHI_TYPE_A  ...  PHI_TYPE_T  PHI_TYPE_AL  \\\n",
+       "0         1.0         1.0         1.0  ...         2.0          2.0   \n",
+       "1         1.0         1.0         1.0  ...         2.0          2.0   \n",
+       "2         NaN         NaN         NaN  ...         NaN          NaN   \n",
+       "3         1.0         1.0         2.0  ...         2.0          2.0   \n",
+       "4         1.0         1.0         1.0  ...         2.0          2.0   \n",
+       "\n",
+       "   PHI_TYPE_M  PHI_TYPE_O  PHI_premium_yn  PHI_premium  PHI_claim_yn  \\\n",
+       "0         2.0         1.0             1.0     120000.0           1.0   \n",
+       "1         2.0         1.0             1.0     118000.0           2.0   \n",
+       "2         NaN         NaN             1.0      48710.0           2.0   \n",
+       "3         2.0         2.0             3.0      62800.0           2.0   \n",
+       "4         2.0         1.0             1.0     201717.0           2.0   \n",
+       "\n",
+       "   PHI_benefit_yn  PHI_benefit  year  \n",
+       "0             1.0      60000.0  2019  \n",
+       "1             NaN          NaN  2019  \n",
+       "2             NaN          NaN  2019  \n",
+       "3             NaN          NaN  2019  \n",
+       "4             NaN          NaN  2019  \n",
+       "\n",
+       "[5 rows x 21 columns]"
+      ]
+     },
+     "execution_count": 194,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "phi_only.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 195,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# csv 파일로 저장\n",
+    "phi_only.to_csv('C:\\\\Users\\\\user\\\\Desktop\\\\중간프로젝트\\\\의료패널 데이터\\\\csv파일\\\\phi_only.csv', index=False)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "base",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
## 1. PHI 데이터 구조 확인
### 1) a, b, c에 "year" 변수 추가하기 (병합 후 각 데이터의 구분을 위해)
<핵심 코드>
`a_phi["year"] = 2019
b_phi["year"] = 2020
c_phi["year"] = 2021`

### 2) b_phi 의 PHI_PID 컬럼이 a_phi, c_phi와는 달리 공백이 많이 포함되어 있다
- 추후 PHI_PID의 글자 수를 기준으로 (9글자 이상/이하) 중복가입 / 독립가입 여부를 구분하므로 b_phi["PHI_PID"] 값의 공백을 제거해줘야한다.

<핵심 코드>
`b_phi["PHI_PID"] = b_phi["PHI_PID"].str.strip()`

## **2. 데이터 병합**
- 변수명 변경, 결측값 변경, 단독가입 구분의 용이성을 위해서 데이터를 병합하여 한번에 변환함!

<핵심 코드>
`phi = pd.concat([a_phi, b_phi, c_phi])`

## **3. 변수명 변경**
- 기존 컬럼명을 변경한다.
- 기존 컬럼명 : 
`['HHID', 'PHI_N', 'PHI_PID', 'PHI_PID1', 'PHI_PID2', 'PHI_PID3', 'PHI_PID4', 'PHI_PID5', 'PHI1', 'PHI2', 'PHI3', 'PHI4', 'PHI4_1_D', 'PHI4_2_D', 'PHI4_3_D', 'PHI4_4_D', 'PHI4_5_D', 'PHI4_6_D', 'PHI4_7_D', 'PHI4_8_D', 'PHI5', 'PHI6', 'PHR1', 'PHR2', 'PHR3', 'year']`

<핵심 코드>
`phi.columns = ["HHID", "PHI_N","PHI_PID","PIDWON1","PIDWON2","PIDWON3","PIDWON4","PIDWON5", "PHI_Y","PHI_M","PHI_FORM","PHI_TYPE","PHI_TYPE_D","PHI_TYPE_C","PHI_TYPE_A","PHI_TYPE_N","PHI_TYPE_T","PHI_TYPE_AL","PHI_TYPE_M","PHI_TYPE_O","PHI_premium_yn","PHI_premium","PHI_claim_yn","PHI_benefit_yn","PHI_benefit", "year"]`

## 4. 결측값 변경
- '-9'로 기입된 결측값을 na로 변경
- int 형과 object 형 모두 변경될 수 있도록 신경써야함!

<핵심코드>
`import numpy as np
phi[phi==-9] = np.nan
phi[phi=='-9'] = np.nan`

## 5. 가구 별 단독 가입만 추출
- PHI_PID 값의 길이가 9 미만이면 단독 가입으로 생각하고 이를 만족하는 행만 추출하여 phi_only 데이터 프레임 생성
- 이후, PIDWON1 만 PHIWON으로 컬럼명 변경하여 사용. 나머지 PIDWON을 의미하는 컬럼은 탈락

<핵심 코드>
```
phi_only = phi.loc[phi["PHI_PID"].str.len() < 9, :]
# PHI_PID, PIDWON2~5 삭제
phi_only.drop(["PHI_PID","PIDWON2","PIDWON3","PIDWON4","PIDWON5"], axis=1, inplace=True)
# PIDWON 변수명 변경
phi_only = phi_only.rename(columns={"PIDWON1":"PIDWON"})
```
